### PR TITLE
fediverse:creator para todas as pessoas cadastradas

### DIFF
--- a/header.php
+++ b/header.php
@@ -17,13 +17,6 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="robots" content="noarchive">
 	<?php wp_head(); ?>
-
-	<?php if ( is_single() ) :
-		$author_id = get_post_field( 'post_author', get_queried_object_id() );
-		if ( get_the_author_meta( 'display_name', $author_id ) === 'Rodrigo Ghedin' ) {
-			echo '<meta name="fediverse:creator" content="@manualdousuario@mastodon.social" />';
-		}
-	endif; ?>
 	<link rel="profile" href="https://gmpg.org/xfn/11">
 </head>
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: featured-images, threaded-comments
 Requires at least: 4.5
 Tested up to: 8.1.12
 Requires PHP: 5.6
-Stable tag: 3.5.1
+Stable tag: 3.5.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 
@@ -42,6 +42,9 @@ More information: https://github.com/Automattic/_s
 Dez includes support for WooCommerce and for Infinite Scroll in Jetpack.
 
 == Changelog ==
+
+= 3.5.2 - Jan 17 2025 =
+* Remove script “hard coded” no `header.php` para atribuir posts ao autor #1 no Mastodon em prol de plugin que estende funcionalidade a todas as pessoas cadastradas.
 
 = 3.5.1 - Jan 16 2025 =
 * Corrige margem inferior da classe `.footnotes`

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://manualdousuario.net/
 Author: Rodrigo Ghedin
 Author URI: https://rodrigo.ghed.in/
 Description: Manual do Usuário Theme
-Version: 3.5.1
+Version: 3.5.2
 Tested up to: 8.1.12
 Requires PHP: 5.6
 License: GNU General Public License v2 or later


### PR DESCRIPTION
* Remove script “hard coded” no `header.php` para atribuir posts ao autor 1 (eu! 😬) no Mastodon em prol de plugin ([Simple fediverse:creator](https://wordpress.org/plugins/simple-fediverse-creator/)) que estende funcionalidade a todas as pessoas cadastradas.